### PR TITLE
Fix shmat() return value checking. (#76)

### DIFF
--- a/afl-analyze.c
+++ b/afl-analyze.c
@@ -180,7 +180,7 @@ static void setup_shm(void) {
 
   trace_bits = shmat(shm_id, NULL, 0);
   
-  if (!trace_bits) PFATAL("shmat() failed");
+  if (trace_bits == (void *)-1) PFATAL("shmat() failed");
 
 }
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1379,7 +1379,7 @@ EXP_ST void setup_shm(void) {
 
   trace_bits = shmat(shm_id, NULL, 0);
   
-  if (!trace_bits) PFATAL("shmat() failed");
+  if (trace_bits == (void *)-1) PFATAL("shmat() failed");
 
 }
 

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -163,7 +163,7 @@ static void setup_shm(void) {
 
   trace_bits = shmat(shm_id, NULL, 0);
   
-  if (!trace_bits) PFATAL("shmat() failed");
+  if (trace_bits == (void *)-1) PFATAL("shmat() failed");
 
 }
 

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -192,7 +192,7 @@ static void setup_shm(void) {
 
   trace_bits = shmat(shm_id, NULL, 0);
   
-  if (!trace_bits) PFATAL("shmat() failed");
+  if (trace_bits == (void *)-1) PFATAL("shmat() failed");
 
 }
 


### PR DESCRIPTION
* fix a little mistake

http://man7.org/linux/man-pages/man3/shmat.3p.html

if `shmat` fail, it will return -1.
>        On success, a valid shared memory identifier is returned.  On error,
       -1 is returned, and errno is set to indicate the error.

* if shmat() is error, it will return -1.
So I modify all error condition.