### PR TITLE
Fix a typo filename comparison in the fuzzer (#139)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   # Test fuzzing libFuzzer targets and trace-pc-guard instrumentation.
   - clang -g -fsanitize-coverage=trace-pc-guard ./test-libfuzzer-target.c -c
   - clang -c -w llvm_mode/afl-llvm-rt.o.c
-  - wget https://raw.githubusercontent.com/llvm/llvm-project/master/compiler-rt/lib/fuzzer/afl/afl_driver.cpp
+  - wget https://raw.githubusercontent.com/llvm/llvm-project/main/compiler-rt/lib/fuzzer/afl/afl_driver.cpp
   - clang++ afl_driver.cpp afl-llvm-rt.o.o test-libfuzzer-target.o -o test-libfuzzer-target
   - timeout --preserve-status 5s ./afl-fuzz -i seeds -o out/ -- ./test-libfuzzer-target
   - cd qemu_mode

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1488,7 +1488,7 @@ static void read_testcases(void) {
 
     /* This also takes care of . and .. */
 
-    if (!S_ISREG(st.st_mode) || !st.st_size || strstr(fn, "/README.txt")) {
+    if (!S_ISREG(st.st_mode) || !st.st_size || strstr(fn, "/README.testcases")) {
 
       ck_free(fn);
       ck_free(dfn);


### PR DESCRIPTION
* Fix wrong default README filename fron 'README.txt' to 'README.testcases'

* Update afl_driver.cpp url of llvm-project